### PR TITLE
Implement purge conditions and iOS simulator targeting in debug builds

### DIFF
--- a/BlogMaui/Areas/Blog/Model.cs
+++ b/BlogMaui/Areas/Blog/Model.cs
@@ -14,6 +14,9 @@ public record SiteDeleted(Site site, DateTime deletedAt) { }
 [FactType("Blog.Site.Restored")]
 public record SiteRestored(SiteDeleted deleted) { }
 
+[FactType("Blog.Site.Purged")]
+public record SitePurged(SiteDeleted deleted) { }
+
 [FactType("Blog.Site.Name")]
 public record SiteName(Site site, string value, SiteName[] prior) { }
 

--- a/BlogMaui/Areas/Blog/Posts/PostNewViewModel.cs
+++ b/BlogMaui/Areas/Blog/Posts/PostNewViewModel.cs
@@ -1,8 +1,6 @@
-using BlogMaui.Components;
 using CommunityToolkit.Mvvm.ComponentModel;
 using CommunityToolkit.Mvvm.Input;
 using Jinaga;
-using System.Collections.Immutable;
 using System.Windows.Input;
 
 namespace BlogMaui.Areas.Blog.Posts;

--- a/BlogMaui/Areas/Blog/Sites/SiteListViewModel.cs
+++ b/BlogMaui/Areas/Blog/Sites/SiteListViewModel.cs
@@ -5,6 +5,7 @@ using Microsoft.Extensions.Logging;
 using CommunityToolkit.Mvvm.ComponentModel;
 
 using Jinaga;
+using Jinaga.Extensions;
 using Jinaga.Maui.Authentication;
 using Jinaga.Maui.Binding;
 using System.Windows.Input;
@@ -56,7 +57,8 @@ public partial class SiteListViewModel : ObservableObject, ILifecycleManaged
                 where site.creator == user &&
                     !facts.Any<SiteDeleted>(deleted => deleted.site == site &&
                         !facts.Any<SiteRestored>(restored => restored.deleted == deleted)
-                    )
+                    ) &&
+                    site.Successors().No<SitePurged>(purged => purged.deleted.site)
                 select new
                 {
                     site,

--- a/BlogMaui/BlogMaui.csproj
+++ b/BlogMaui/BlogMaui.csproj
@@ -35,7 +35,7 @@
     <CodesignEntitlements>Platforms\iOS\Entitlements.plist</CodesignEntitlements>
   </PropertyGroup>
   <PropertyGroup Condition="$(TargetFramework.Contains('-ios')) and '$(Configuration)' == 'Debug'">
-    <RuntimeIdentifier>iossimulator-x64</RuntimeIdentifier>
+    <RuntimeIdentifier>iossimulator-arm64</RuntimeIdentifier>
   </PropertyGroup>
   <ItemGroup>
     <!-- App Icon -->

--- a/BlogMaui/BlogMaui.csproj
+++ b/BlogMaui/BlogMaui.csproj
@@ -34,6 +34,9 @@
     <CodesignProvision>Blog MAUI Provisioning</CodesignProvision>
     <CodesignEntitlements>Platforms\iOS\Entitlements.plist</CodesignEntitlements>
   </PropertyGroup>
+  <PropertyGroup Condition="$(TargetFramework.Contains('-ios')) and '$(Configuration)' == 'Debug'">
+    <RuntimeIdentifier>iossimulator-x64</RuntimeIdentifier>
+  </PropertyGroup>
   <ItemGroup>
     <!-- App Icon -->
     <MauiIcon Include="Resources\AppIcon\appicon.svg" ForegroundFile="Resources\AppIcon\appiconfg.svg" Color="#EEEEEE" />

--- a/BlogMaui/BlogMaui.csproj
+++ b/BlogMaui/BlogMaui.csproj
@@ -53,9 +53,9 @@
   <ItemGroup>
     <PackageReference Include="CommunityToolkit.Maui" Version="7.0.1" />
     <PackageReference Include="CommunityToolkit.Mvvm" Version="8.2.2" />
-    <PackageReference Include="Jinaga" Version="1.0.42-g9be2c7816d" />
-    <PackageReference Include="Jinaga.Maui" Version="1.0.3-g9be2c7816d" />
-    <PackageReference Include="Jinaga.Store.SQLite" Version="1.0.15-g9be2c7816d" />
+    <PackageReference Include="Jinaga" Version="1.0.51-g23c008c521" />
+    <PackageReference Include="Jinaga.Maui" Version="1.0.3-g23c008c521" />
+    <PackageReference Include="Jinaga.Store.SQLite" Version="1.0.29-g23c008c521" />
     <PackageReference Include="MetroLog.Maui" Version="2.1.0" />
     <PackageReference Include="Microsoft.Extensions.Http" Version="8.0.0" />
     <PackageReference Include="Microsoft.Maui.Controls" Version="$(MauiVersion)" />

--- a/BlogMaui/BlogMaui.csproj
+++ b/BlogMaui/BlogMaui.csproj
@@ -50,9 +50,9 @@
   <ItemGroup>
     <PackageReference Include="CommunityToolkit.Maui" Version="7.0.1" />
     <PackageReference Include="CommunityToolkit.Mvvm" Version="8.2.2" />
-    <PackageReference Include="Jinaga" Version="1.0.34" />
-    <PackageReference Include="Jinaga.Maui" Version="1.0.0" />
-    <PackageReference Include="Jinaga.Store.SQLite" Version="1.0.0" />
+    <PackageReference Include="Jinaga" Version="1.0.42-g9be2c7816d" />
+    <PackageReference Include="Jinaga.Maui" Version="1.0.3-g9be2c7816d" />
+    <PackageReference Include="Jinaga.Store.SQLite" Version="1.0.15-g9be2c7816d" />
     <PackageReference Include="MetroLog.Maui" Version="2.1.0" />
     <PackageReference Include="Microsoft.Extensions.Http" Version="8.0.0" />
     <PackageReference Include="Microsoft.Maui.Controls" Version="$(MauiVersion)" />

--- a/BlogMaui/JinagaConfig.cs
+++ b/BlogMaui/JinagaConfig.cs
@@ -84,6 +84,7 @@ public static class JinagaConfig
             opt.SQLitePath = Path.Combine(
                 Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData),
                 "blog.db");
+            opt.PurgeConditions = DefinePurgeConditions;
             opt.LoggerFactory = services.GetRequiredService<ILoggerFactory>();
         });
         return jinagaClient;
@@ -93,6 +94,8 @@ public static class JinagaConfig
         AuthorizationRules.Describe(Authorize);
     public static string Distribution() =>
         DistributionRules.Describe(Distribute);
+    public static string Purge() =>
+        PurgeConditions.Describe(DefinePurgeConditions);
 
     private static AuthorizationRules Authorize(AuthorizationRules r) => r
         .Any<User>()
@@ -194,4 +197,8 @@ public static class JinagaConfig
                     next.prior.Contains(title))
             select title
         )).With(post => post.site.creator);
+
+    private static PurgeConditions DefinePurgeConditions(PurgeConditions p) => p
+        .Purge<Site>().WhenExists<SitePurged>(purged => purged.deleted.site)
+        ;
 }

--- a/BlogMaui/JinagaConfig.cs
+++ b/BlogMaui/JinagaConfig.cs
@@ -1,6 +1,7 @@
 ﻿using System.Collections.Immutable;
 using BlogMaui.Areas.Blog;
 using Jinaga;
+using Jinaga.Extensions;
 using Jinaga.Http;
 using Jinaga.Maui.Authentication;
 using Jinaga.Store.SQLite;
@@ -129,7 +130,8 @@ public static class JinagaConfig
                 !facts.Any<SiteDeleted>(deleted =>
                     deleted.site == site &&
                         !facts.Any<SiteRestored>(restored =>
-                            restored.deleted == deleted))
+                            restored.deleted == deleted)) &&
+                site.Successors().No<SitePurged>(purged => purged.deleted.site)
             select new {
                 site,
                 names =

--- a/BlogMaui/Platforms/Android/MainActivity.cs
+++ b/BlogMaui/Platforms/Android/MainActivity.cs
@@ -1,7 +1,4 @@
-﻿using Android.App;
-using Android.Content.PM;
-
-namespace BlogMaui;
+﻿namespace BlogMaui;
 [Activity(Theme = "@style/Maui.SplashTheme", MainLauncher = true, ConfigurationChanges = ConfigChanges.ScreenSize | ConfigChanges.Orientation | ConfigChanges.UiMode | ConfigChanges.ScreenLayout | ConfigChanges.SmallestScreenSize | ConfigChanges.Density)]
 public class MainActivity : MauiAppCompatActivity
 {

--- a/BlogMaui/Platforms/Android/MainApplication.cs
+++ b/BlogMaui/Platforms/Android/MainApplication.cs
@@ -1,7 +1,4 @@
-﻿using Android.App;
-using Android.Runtime;
-
-namespace BlogMaui;
+﻿namespace BlogMaui;
 [Application]
 public class MainApplication : MauiApplication
 {


### PR DESCRIPTION
Introduce purge conditions for site management and enhance the project configuration to target the iOS simulator during debug builds. Clean up namespaces and update package references to private versions.