### PR TITLE
Update iOS SDK version to 18.0

### DIFF
--- a/.github/workflows/ios.yml
+++ b/.github/workflows/ios.yml
@@ -39,7 +39,7 @@ jobs:
     - name: Use latest Xcode
       uses: maxim-lobanov/setup-xcode@v1
       with:
-        xcode-version: latest
+        xcode-version: 16.0
     - name: Get Xcode version
       run: xcodebuild -version
     - name: Install workloads

--- a/BlogMaui/BlogMaui.csproj
+++ b/BlogMaui/BlogMaui.csproj
@@ -18,7 +18,7 @@
     <!-- Versions -->
     <ApplicationDisplayVersion>1.0</ApplicationDisplayVersion>
     <ApplicationVersion>1</ApplicationVersion>
-    <SupportedOSPlatformVersion Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'ios'">11.0</SupportedOSPlatformVersion>
+    <SupportedOSPlatformVersion Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'ios'">18.0</SupportedOSPlatformVersion>
     <SupportedOSPlatformVersion Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'maccatalyst'">13.1</SupportedOSPlatformVersion>
     <SupportedOSPlatformVersion Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'android'">21.0</SupportedOSPlatformVersion>
     <SupportedOSPlatformVersion Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'windows'">10.0.17763.0</SupportedOSPlatformVersion>


### PR DESCRIPTION
Update the build environment to use Xcode 16.0 or later and update iOS platform version.

* Update `SupportedOSPlatformVersion` for iOS to `18.0` in `BlogMaui/BlogMaui.csproj`.
* Update `xcode-version` to `16.0` in `.github/workflows/ios.yml`.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/jinaga/BlogMaui/pull/38?shareId=711ba16a-7f61-4066-a1cd-8389ad29be68).